### PR TITLE
Update documentation for options replay and analysis migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ Please provide step-by-step setup instructions, recommend appropriate templates,
 
 ### **System Optimization (Latest)**
 - **Cleaned Architecture**: Removed redundant files and streamlined codebase
-- **Dual Configuration System**: 
+- **Dual Configuration System**:
   - `config/config.py` - Broker connections and data provider settings
   - `config/unified_config.py` - Strategy parameters and risk management
-- **Enhanced Data Providers**: Added Binance support for cryptocurrency data
-- **Improved Documentation**: Comprehensive guides and troubleshooting
+- **Derivatives Pipeline**: Phase 1–4 options validation and replay flows are production-tested with hybrid pricing, Upstox ingestion, and full multi-ticker coverage.【F:src/core/options/PHASE4_COMPLETE.md†L1-L24】【F:src/core/options/validation/README.md†L1-L67】
+- **Analysis Migration**: Nine legacy analytics have been ported to the config-driven framework so trade diagnostics, ticker ranking, and validation checks run without hardcoded paths.【F:analysis/generic/scripts/02_trade_type_analysis.py†L1-L41】【F:analysis/generic/scripts/09_validation_check.py†L1-L39】
+- **Enhanced Data Providers**: Binance crypto feed and the Indian equities master pipeline combine broker APIs with YFinance fallbacks for reference data and discovery.【F:src/core/etl/data_provider/binance_provider.py†L21-L92】【F:src/data_tools/indian_equities_master/discovery.py†L7-L33】
+- **Parquet-First Storage**: Unified loader/fetcher modules read and write ticker-first parquet layouts with automatic CSV fallback when needed.【F:src/core/etl/loader.py†L23-L74】【F:src/core/etl/data_fetcher.py†L93-L197】
 
 ### **Configuration Architecture**
 The system uses a **dual configuration approach** for optimal separation of concerns:
@@ -77,6 +79,11 @@ This design allows independent management of:
 - **Live Data Fetching**: Real-time and historical data
 - **Strategy Framework**: Modular, extensible strategy system
 
+### **🧮 Options & Derivatives**
+- **Replay Engine**: Converts equity trade ledgers into option executions with lifecycle tracking and portfolio-aware risk checks.【F:src/core/options/replay/engine.py†L1-L120】【F:src/core/options/replay/trade_mapper.py†L1-L74】
+- **Hybrid Pricing**: Combines actual Upstox OHLC chains with Black-Scholes synthetic fills, including automatic fallbacks and validation reports.【F:src/core/options/validation/pricing_validator.py†L257-L335】【F:src/core/options/replay/pricing.py†L150-L238】
+- **Operational Reports**: Phase completion manifests document throughput, P&L, and data quality for Phase 3 MVP and Phase 4 production tests.【F:src/core/options/PHASE3_COMPLETE.md†L1-L32】【F:src/core/options/PHASE4_COMPLETE.md†L1-L35】
+
 ### **🛡️ Risk Management**
 - **Portfolio-Level Controls**: Position sizing, drawdown limits
 - **Trade-Level Protection**: Stop-loss, take-profit, trailing stops
@@ -88,12 +95,17 @@ This design allows independent management of:
 - **Interactive Charts**: Price action, signals, portfolio performance
 - **Statistical Analysis**: Sharpe ratio, maximum drawdown, win rate
 - **Export Capabilities**: CSV, JSON, PNG formats
+- **Config-Driven Analytics**: Trade type analysis, stop-loss simulation, and validation sweeps run through reusable modules with YAML-controlled inputs.【F:analysis/generic/scripts/04_stop_loss_simulation.py†L1-L44】【F:analysis/generic/modules/config_loader.py†L300-L373】
 
 ### **⚡ Performance**
 - **Parallel Processing**: Multi-core execution
 - **Efficient Data Handling**: Optimized for large datasets
 - **Caching System**: Intelligent data caching
 - **Modular Architecture**: Clean, maintainable codebase
+
+### **₿ Crypto Coverage**
+- **BTC & Top 30 Tokens**: Binance provider ships symbol metadata and fetch routines for Bitcoin pairs and the highest-liquidity USDT listings.【F:src/core/etl/data_provider/binance_provider.py†L21-L122】【F:config/binance_instruments.csv†L13-L70】
+- **Unified Config Templates**: Crypto-friendly defaults control trade file formats, leverage, and data cadence via YAML templates.【F:config/templates/aggressive.yaml†L79-L92】【F:config/unified_config.py†L118-L156】
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This design allows independent management of:
 - **Replay Engine**: Converts equity trade ledgers into option executions with lifecycle tracking and portfolio-aware risk checks.【F:src/core/options/replay/engine.py†L1-L120】【F:src/core/options/replay/trade_mapper.py†L1-L74】
 - **Hybrid Pricing**: Combines actual Upstox OHLC chains with Black-Scholes synthetic fills, including automatic fallbacks and validation reports.【F:src/core/options/validation/pricing_validator.py†L257-L335】【F:src/core/options/replay/pricing.py†L150-L238】
 - **Operational Reports**: Phase completion manifests document throughput, P&L, and data quality for Phase 3 MVP and Phase 4 production tests.【F:src/core/options/PHASE3_COMPLETE.md†L1-L32】【F:src/core/options/PHASE4_COMPLETE.md†L1-L35】
+- **Hypothesis Lifecycle & Tests**: Follow `src/core/options/README.md` for the six-step hypothesis-to-replay playbook plus the unit and integration checks that keep synthesis deterministic.【F:src/core/options/README.md†L49-L136】
 
 ### **🛡️ Risk Management**
 - **Portfolio-Level Controls**: Position sizing, drawdown limits

--- a/analysis/IMPLEMENTATION_STATUS.md
+++ b/analysis/IMPLEMENTATION_STATUS.md
@@ -202,6 +202,8 @@ Phase 3: Script Migration           ██████████████�
 Phase 4: Documentation              ████████████████████ 100% ✅
 Phase 5: Testing (not started)      ░░░░░░░░░░░░░░░░░░░░   0% ⏳
 
+*Manual harness available*: `analysis/run.py` already sequences generic and portfolio modules using the shared config loader, so day-to-day reviews rely on a repeatable entry point even before CI automation lands.【F:analysis/run.py†L1-L188】
+
 Overall: ████████████░░░░░░░  78% (Testing automation outstanding)
 ```
 

--- a/analysis/IMPLEMENTATION_STATUS.md
+++ b/analysis/IMPLEMENTATION_STATUS.md
@@ -97,49 +97,33 @@
 
 ### **Phase 3: Script Migration** ⏳ IN PROGRESS
 
-**Objective**: Migrate 15+ scripts from `mse_analysis/` to `generic/` with YAML config support
+**Objective**: Move legacy analytics into the config-driven, strategy-agnostic framework.
 
-**Progress**: 2 of 15 scripts migrated (13%)
+**Progress**: 9 of 10 generic modules migrated (90%)
 
-#### **✅ Completed Scripts (2)**:
+#### **✅ Completed Modules (9)**
 
-1. **`generic/scripts/01_basic_eda.py`** ✅
-   - **Purpose**: Overall statistics, win rate, profit factor, ticker performance
-   - **Lines**: 245
-   - **Features**:
-     - Uses config loader module
-     - Validates trade data
-     - Generates JSON statistics + CSV summaries + Markdown report
-     - Sample mode for quick testing
-   - **Status**: Ready to use
+1. `01_basic_eda.py` – Core statistics, ticker scorecards, Markdown reporting
+2. `02_trade_type_analysis.py` – Directional (Buy vs Sell) deep dive with ticker bias export
+3. `03_cascade_analysis.py` – Sequential pattern tagging and cascade diagnostics
+4. `04_stop_loss_simulation.py` – Threshold sweep + recommendation engine
+5. `05_ticker_ranking.py` – Composite scoring with tiered outputs and liquidity filters
+6. `06_risk_adjusted_patterns.py` – Motif heatmaps across volatility and duration buckets
+7. `07_top50_vs_overall.py` – Top 50 versus universe benchmarking feed for portfolio scripts
+8. `08_top50_pattern_breakdown.py` – Behavioural breakdown of the curated Top 50 basket
+9. `09_validation_check.py` – Guard-rail checks + Markdown dossier before portfolio construction
 
-2. **`generic/scripts/03_cascade_analysis.py`** ✅
-   - **Purpose**: Identify sequential trade patterns (cascading wins/losses)
-   - **Lines**: 320
-   - **Features**:
-     - Tags trades: FIRST_TRADE_OF_DAY, WINNING_CASCADE, LOSING_CASCADE, etc.
-     - Time gap analysis (0-5 min, 5-15 min, 30-60 min, etc.)
-     - Performance comparison by cascade type
-     - Critical for portfolio construction (filter anti-cascading trades)
-   - **Status**: Ready to use
+All migrated modules share the reusable loaders, support YAML toggles, and emit CSV/JSON/Markdown artefacts under the modular output schema.
 
-#### **⏳ Remaining Scripts (13)**:
+#### **⏳ Remaining Workstreams**
 
-| Script | Source Location | Target Location | Complexity | Priority |
-|--------|----------------|-----------------|------------|----------|
-| `02_trade_type_analysis.py` | mse_analysis/scripts/ | generic/scripts/ | Low | High |
-| `04_ticker_ranking.py` | mse_analysis/scripts/05_ticker_ranking.py | generic/scripts/ | Low | High |
-| `05_exit_timing_analysis.py` | mse_analysis/scripts/04_exit_timing_analysis.py | generic/scripts/ | Medium | Medium |
-| `06_stop_loss_simulation.py` | mse_analysis/scripts/03_stop_loss_simulation.py | generic/scripts/ | Medium | Medium |
-| `07_risk_adjusted_patterns.py` | mse_analysis/scripts/14_risk_adjusted_pattern_analysis.py | generic/scripts/ | Medium | Low |
-| `08_top50_vs_overall.py` | mse_analysis/scripts/15_comprehensive_top50_vs_overall_analysis.py | comparative_analysis/scripts/ | Medium | Low |
-| `09_validation_check.py` | mse_analysis/scripts/08_validation_check_analysis.py | generic/scripts/ | Low | Low |
-| **MSE-Specific (to strategy_specific/mse/)**: |
-| `macd_exit_optimization.py` | mse_analysis/scripts/07_macd_exit_threshold_optimization.py | strategy_specific/mse/ | High | Medium |
-| **Portfolio Construction Scripts**: |
-| `portfolio_prep_scripts.py` | mse_analysis/scripts/18-20_*.py | portfolio_construction/scripts/ | Medium | Low |
+| Work Item | Target Location | Status | Notes |
+|-----------|-----------------|--------|-------|
+| `05_exit_timing_analysis.py` | `analysis/generic/scripts/` | Pending | Final generic module to port; still tied to legacy notebooks. |
+| Portfolio prep trio (`18-20_*.py`) | `analysis/portfolio_construction/scripts/` | In progress | Scripts exist but retain absolute paths; need config-loader adoption. |
+| `macd_exit_optimization.py` | `analysis/strategy_specific/mse/` | Pending | Must be relocated under strategy-specific tree with config hooks. |
 
-**Migration Pattern**:
+**Migration Pattern** (unchanged):
 ```python
 # OLD (hardcoded)
 trade_file = "/mnt/batch/.../outputs/20250915_121714/mse_backtesting/.../all_trade_merged.csv"
@@ -154,7 +138,7 @@ paths = resolve_paths(config)
 trades = load_trades(config, paths)
 ```
 
-**Status**: ⏳ **13% Complete** (2/15 scripts)
+**Status**: ⏳ **90% Complete** (9/10 generic modules) — portfolio & strategy-specific migrations remain
 
 ---
 
@@ -214,11 +198,11 @@ trades = load_trades(config, paths)
 ```
 Phase 1: Cleanup & Foundation       ████████████████████ 100% ✅
 Phase 2: Reusable Modules           ████████████████████ 100% ✅
-Phase 3: Script Migration           ███░░░░░░░░░░░░░░░░░  13% ⏳
+Phase 3: Script Migration           ██████████████░░░░░░  90% ⏳
 Phase 4: Documentation              ████████████████████ 100% ✅
 Phase 5: Testing (not started)      ░░░░░░░░░░░░░░░░░░░░   0% ⏳
 
-Overall: ████████░░░░░░░░░░░░  42% (4 of 5 phases complete)
+Overall: ████████████░░░░░░░  78% (Testing automation outstanding)
 ```
 
 ---
@@ -321,31 +305,29 @@ trades = load_trades(config, paths)
 
 ---
 
-### **4. Generic Analysis Scripts** ✅ (2 scripts ready)
+### **4. Generic Analysis Scripts** ✅ (9 modules ready)
 
-#### **Script 1: Basic EDA**
+**Delivered Modules**
+- `01_basic_eda.py` – core KPIs, time-of-day splits, Markdown dashboard
+- `02_trade_type_analysis.py` – directional bias scorecards + ticker breakdowns
+- `03_cascade_analysis.py` – cascade tags, transition matrices, anti-revenge heuristics
+- `04_stop_loss_simulation.py` – configurable stop-loss sweeps with optimal threshold recommendation
+- `05_ticker_ranking.py` – composite scoring, tiering, and liquidity sanity checks
+- `06_risk_adjusted_patterns.py` – volatility × duration heatmaps for motif discovery
+- `07_top50_vs_overall.py` – benchmarks curated baskets versus the full universe
+- `08_top50_pattern_breakdown.py` – microstructure profiling of the Top-50 roster
+- `09_validation_check.py` – guard-rail dossier before portfolio construction
+
+Each script consumes the shared loaders, respects YAML toggles, and can run in sampling mode for rapid experimentation. Outputs span CSV/JSON artifacts plus Markdown reports for human review.
+
 ```powershell
+# Example bundle run
 python 01_basic_eda.py --config ../../config.yaml
+python 02_trade_type_analysis.py --config ../../config.yaml --sample 10000
+python 04_stop_loss_simulation.py --config ../../config.yaml
+python 05_ticker_ranking.py --config ../../config.yaml
+python 09_validation_check.py --config ../../config.yaml
 ```
-
-**Outputs**:
-- Overall statistics (win rate, profit factor)
-- Buy vs Sell comparison
-- Ticker-level performance
-- JSON + CSV + Markdown report
-
-#### **Script 2: Cascade Analysis**
-```powershell
-python 03_cascade_analysis.py --config ../../config.yaml
-```
-
-**Outputs**:
-- Tagged trades CSV (with cascade patterns)
-- Performance by pattern type
-- Time gap analysis
-- Recommendations for portfolio construction
-
-**Key Insight**: Identifies if "trades after a loss" underperform → can filter them in portfolio construction.
 
 ---
 
@@ -389,50 +371,19 @@ analysis:
 
 ## 🚧 **WHAT REMAINS TO BE DONE**
 
-### **Priority 1: High-Impact Scripts** (Estimated: 2-3 days)
+### **Priority 1: Final Generic Module** (Est. 1-2 days)
 
-1. **`02_trade_type_analysis.py`** (Buy vs Sell deep dive)
-   - Directional performance comparison
-   - Risk/reward by direction
-   - Sector preferences
+1. **`05_exit_timing_analysis.py`** – Port the holding-period optimizer onto the shared loaders, add YAML-controlled buckets, and emit CSV/Markdown summaries for downstream use.
 
-2. **`04_ticker_ranking.py`** (Critical for portfolio construction)
-   - Rank tickers by weighted score
-   - Filter top 50 performers
-   - Input to portfolio optimization
+### **Priority 2: Portfolio Integration** (Est. 3-4 days)
 
-3. **`05_exit_timing_analysis.py`** (Holding period optimization)
-   - Optimal duration analysis
-   - Peak capture metrics
+2. **Portfolio prep trio (`18-20_*.py`)** – Replace absolute paths with `config_loader` helpers, accept ticker subsets from the ranking module, and document new CLI entry points.
+3. **Master optimizer harness** – Refactor `master_portfolio_optimizer.py` to use the merged trade dataset + config toggles instead of static directories.
 
-### **Priority 2: Portfolio Integration** (Estimated: 1-2 days)
+### **Priority 3: Strategy-Specific & Testing** (Est. 3-4 days)
 
-4. **Portfolio scripts (18-20)** - Link to generic analysis
-   - Use cascade tags from cascade_analysis
-   - Use top 50 from ticker_ranking
-   - Already mostly generic, just need config support
-
-### **Priority 3: Testing & Validation** (Estimated: 2-3 days)
-
-5. **End-to-end workflow test**
-   - Run backtest → merge → analyze → portfolio
-   - Verify all outputs
-   - Test with different strategies
-
-6. **Documentation videos/screenshots** (optional)
-   - Screen recordings of workflow
-   - Troubleshooting examples
-
-### **Priority 4: Strategy-Specific Organization** (Estimated: 1 day)
-
-7. **Move strategy_optimization/**
-   - `mv analysis/strategy_optimization analysis/strategy_specific/mse/`
-   - Update imports
-   - Add README
-
-8. **Create strategy template**
-   - Template for adding new strategies
-   - Example: Bollinger Bands optimization structure
+4. **`macd_exit_optimization.py` relocation** – Move into `analysis/strategy_specific/mse/`, wire into YAML, and preserve legacy behaviour via adapters.
+5. **End-to-end regression bundle** – Automate `backtest → merge → generic analytics → portfolio` using a sample dataset so Phase 5 can focus on CI wiring.
 
 ---
 
@@ -440,12 +391,12 @@ analysis:
 
 ### **Definition of Done**:
 
-- ✅ All 15 generic scripts migrated to `generic/scripts/`
-- ✅ All scripts use YAML config (no hardcoded paths)
+- ✅ All 10 core generic modules migrated to `analysis/generic/scripts/`
+- ✅ Portfolio prep trio consumes YAML-driven outputs (no absolute paths)
 - ✅ End-to-end workflow tested with real data
 - ✅ Documentation complete and accurate
 - ✅ Can run same analysis on different strategies without code changes
-- ✅ Legacy `mse_analysis/` deprecated (archived)
+- ✅ Legacy `mse_analysis/` content archived (complete)
 
 ### **User Acceptance Test**:
 
@@ -463,8 +414,9 @@ cp config_template.yaml config_mse.yaml
 # 3. Merge & analyze (no code changes)
 python ../utils/merge_trades.py --config config_mse.yaml
 python generic/scripts/01_basic_eda.py --config config_mse.yaml
+python generic/scripts/02_trade_type_analysis.py --config config_mse.yaml
 python generic/scripts/03_cascade_analysis.py --config config_mse.yaml
-python generic/scripts/04_ticker_ranking.py --config config_mse.yaml
+python generic/scripts/05_ticker_ranking.py --config config_mse.yaml
 
 # 4. Run portfolio construction
 cd portfolio_construction
@@ -481,16 +433,15 @@ python scripts/02_exit_threshold_optimizer.py --config ../../config_mse.yaml
 
 ## 📈 **ESTIMATED TIMELINE**
 
-**Current Status**: 42% complete
+**Current Status**: 78% complete
 
 **Remaining Work**:
-- **Week 1 (Days 1-3)**: Migrate Priority 1 scripts (3 scripts)
-- **Week 1 (Days 4-5)**: Migrate Priority 2 scripts (portfolio integration)
-- **Week 2 (Days 1-2)**: Testing & bug fixes
-- **Week 2 (Day 3)**: Strategy-specific organization
-- **Week 2 (Days 4-5)**: Final documentation polish & testing
+- **Week 1 (Days 1-2)**: Port `05_exit_timing_analysis.py`
+- **Week 1 (Days 3-5)**: Retrofit portfolio prep trio + master optimizer
+- **Week 2 (Day 1)**: Relocate `macd_exit_optimization.py`
+- **Week 2 (Days 2-3)**: Build automated regression bundle + smoke test
 
-**Total Estimated Time**: 10 working days (2 weeks)
+**Total Estimated Time**: ~6 working days
 
 **Current Investment**: ~5 days already completed
 
@@ -530,7 +481,7 @@ python scripts/02_exit_threshold_optimizer.py --config ../../config_mse.yaml
 
 ### **4. Incremental Migration**
 
-**Decision**: Migrate scripts gradually (2 done, 13 remaining)
+**Decision**: Migrate scripts gradually (9 delivered, final module + portfolio refactor pending)
 
 **Rationale**:
 - Test as we go
@@ -544,8 +495,8 @@ python scripts/02_exit_threshold_optimizer.py --config ../../config_mse.yaml
 
 ### **Issue 1: Recent Backtest Shows 0% Win Rate**
 
-**Status**: ⚠️ Unresolved
-**Impact**: High - Needs investigation before further analysis
+**Status**: ⚠️ Monitor
+**Impact**: Medium — still needs validation before promoting new portfolios
 
 **Observation**:
 ```json
@@ -556,13 +507,11 @@ python scripts/02_exit_threshold_optimizer.py --config ../../config_mse.yaml
 }
 ```
 
-**Potential Causes**:
-1. Data quality issue (missing OHLCV)
-2. Strategy logic bug
-3. Risk manager blocking all trades
-4. Warmup period issue (first 525 minutes invalid)
+**What Changed**:
+- `09_validation_check.py` now emits explicit warnings when win rate = 0 and attaches sample trades for investigation.
+- Guard-rail doc makes the anomaly visible earlier in the workflow.
 
-**Recommendation**: Debug this before migrating more scripts.
+**Next Step**: Use the validation report to inspect sample trades, confirm merge inputs, and rerun after fixing data/strategy filters.
 
 ### **Risk 2: Legacy Script Dependencies**
 
@@ -620,21 +569,18 @@ Windows vs Linux path separators may cause issues.
 
 ### **Today (Day 1)**:
 1. ✅ Review this implementation status document
-2. ⏳ Test `merge_trades.py` with your latest backtest
-3. ⏳ Run `01_basic_eda.py` and verify output
-4. ⏳ Run `03_cascade_analysis.py` and review cascade patterns
+2. ⏳ Run `09_validation_check.py` on the latest merged trades to sanity-check inputs
+3. ⏳ Finalize design notes for `05_exit_timing_analysis.py`
 
 ### **This Week (Days 2-5)**:
-1. ⏳ Migrate `02_trade_type_analysis.py`
-2. ⏳ Migrate `04_ticker_ranking.py`
-3. ⏳ Test portfolio construction integration
-4. ⏳ Debug 0% win rate issue (if exists in your data)
+1. ⏳ Implement `05_exit_timing_analysis.py` using shared loaders
+2. ⏳ Retrofit portfolio prep trio + `master_portfolio_optimizer.py`
+3. ⏳ Re-run generic bundle (01/02/04/05/09) to ensure regressions pass
 
 ### **Next Week (Days 6-10)**:
-1. ⏳ Complete remaining script migrations
-2. ⏳ End-to-end testing
-3. ⏳ Organize strategy_specific/mse/
-4. ⏳ Final documentation updates
+1. ⏳ Relocate `macd_exit_optimization.py` under strategy-specific tree
+2. ⏳ Build automated regression script + document smoke test workflow
+3. ⏳ Prep release notes capturing migration completion & testing results
 
 ---
 
@@ -646,8 +592,8 @@ Windows vs Linux path separators may cause issues.
 - **Module registry**: `analysis.generic.modules[...]` and `analysis.portfolio.modules[...]` declare `inputs`, `outputs`, and optional `depends_on` relations for runner orchestration.
 
 ### 🏗️ Generic Suite (Config-Driven Targets)
-- Scripts to migrate: `basic_eda`, `trade_type_analysis`, `stop_loss_simulation`, `ticker_ranking`, `validation_check`, `risk_adjusted_patterns`, `top50_vs_overall`, `top50_pattern_breakdown`.
-- Each consumes `merged_trades`, emits CSV/Markdown artifacts, and surfaces warnings for the run report.
+- Remaining lift: add `exit_timing_analysis` to the registry and expose portfolio prep trio via module specs.
+- Continue emitting CSV/JSON/Markdown artefacts with warning flags surfaced in the run report.
 
 ### 📈 Portfolio Chain (Config-Aware)
 - Mirrors existing 00→master flow: ranking → anti-cascade filter → sector/correlation prep → combination generation → optimization → equity curves.
@@ -695,23 +641,23 @@ Windows vs Linux path separators may cause issues.
 ## 📊 **SUMMARY**
 
 **What's Working Now**:
-- ✅ Config-driven workflow
-- ✅ Trade file merger
-- ✅ 2 generic analysis scripts (EDA, Cascade)
-- ✅ Comprehensive documentation
+- ✅ Config-driven workflow + trade merger
+- ✅ Nine generic analysis modules on the shared loaders
+- ✅ Comprehensive documentation + module registry updates
 
 **What's In Progress**:
-- ⏳ 13 more script migrations
-- ⏳ End-to-end testing
+- ⏳ Porting `05_exit_timing_analysis.py`
+- ⏳ Retrofitting portfolio prep trio & master optimizer
+- ⏳ Relocating `macd_exit_optimization.py` and wiring regression bundle
 
 **What's Next**:
-- Complete script migrations
-- Test with real data
-- Organize strategy-specific modules
+- Finish exit timing module
+- Replace portfolio hardcoded paths with config helpers
+- Automate regression run + smoke-test checklist
 
-**Current Progress**: **42% Complete** (4 of 5 phases done)
+**Current Progress**: **78% Complete** (Phase 3 near-done; Phase 5 pending)
 
-**Estimated Completion**: **2 weeks** (10 working days)
+**Estimated Completion**: **~6 working days**
 
 ---
 

--- a/analysis/generic/README.md
+++ b/analysis/generic/README.md
@@ -69,6 +69,28 @@ python 09_validation_check.py --config ../../config.yaml
 
 ---
 
+## ✅ Quality Gates & Execution Modes
+
+The generic suite behaves like a regression harness: shared loaders enforce consistent inputs, the YAML schema captures run metadata, and the orchestrator in `analysis/run.py` can replay entire batteries of checks for any strategy without editing code.【F:analysis/generic/modules/config_loader.py†L1-L120】【F:analysis/generic/modules/data_loader.py†L17-L115】【F:analysis/run.py†L1-L188】
+
+| Checkpoint | Primary scripts | What it validates | Adapting to another strategy |
+|------------|-----------------|-------------------|------------------------------|
+| **Data integrity** | `09_validation_check.py`, `modules.data_loader.validate_trade_data` | Confirms required columns, timestamp ordering, and profit consistency before downstream analytics.【F:analysis/generic/scripts/09_validation_check.py†L40-L160】【F:analysis/generic/modules/data_loader.py†L200-L259】 | Point the config to a different `run_id` and merged CSV; the validator will surface schema mismatches instantly. |
+| **Directional bias** | `02_trade_type_analysis.py` | Quantifies buy vs sell profitability, drawdowns, and efficiency deltas so hedging rules can be tuned per strategy.【F:analysis/generic/scripts/02_trade_type_analysis.py†L40-L160】 | Adjust `analysis.generic.modules.trade_type_analysis.config.metrics` or the optional `sample_size` in YAML to focus on the most relevant KPIs. |
+| **Risk protection** | `04_stop_loss_simulation.py` | Sweeps stop-loss thresholds, reports P&L deltas, and highlights saved losses to test capital protection policies.【F:analysis/generic/scripts/04_stop_loss_simulation.py†L47-L160】 | Override `analysis.generic.modules.stop_loss_simulation.config.thresholds` in the config to match the volatility profile of the new strategy. |
+| **Ticker selection** | `05_ticker_ranking.py`, `07_top50_vs_overall.py`, `08_top50_pattern_breakdown.py` | Scores instruments across profitability, drawdown, consistency, and pattern behaviour to create a portfolio-ready whitelist.【F:analysis/generic/scripts/05_ticker_ranking.py†L60-L180】【F:analysis/generic/scripts/07_top50_vs_overall.py†L1-L110】【F:analysis/generic/scripts/08_top50_pattern_breakdown.py†L1-L120】 | Update ranking weights in YAML or feed custom ticker universes; downstream scripts automatically consume the generated CSVs. |
+| **Pattern & regime** | `03_cascade_analysis.py`, `06_risk_adjusted_patterns.py` | Tags cascades vs anti-cascades and measures Sharpe/drawdown per motif to detect behavioural edge or drag.【F:analysis/generic/scripts/03_cascade_analysis.py†L1-L80】【F:analysis/generic/scripts/06_risk_adjusted_patterns.py†L1-L84】 | Enable or disable specific categories via `analysis.generic.modules.cascade_analysis` toggles for different holding styles. |
+
+Run everything hands-free with:
+
+```bash
+python analysis/run.py --config analysis/config.yaml --targets generic
+```
+
+The runner respects module dependencies (for example, ticker ranking before Top-50 comparisons) and writes consolidated logs per execution.【F:analysis/run.py†L41-L188】
+
+---
+
 ## 📊 **Script Details**
 
 ### **01_basic_eda.py**
@@ -78,6 +100,9 @@ python 09_validation_check.py --config ../../config.yaml
 - Trade distribution (Buy vs Sell)
 - Ticker-level performance summary
 - Duration and timing analysis
+
+**Why run it**:
+- First gate that confirms merged trades are numerically sane before deeper studies—win rate, profit factor, and duration checks quickly catch corrupt inputs or broken strategies.【F:analysis/generic/scripts/01_basic_eda.py†L55-L110】
 
 **Outputs**:
 - `output/basic_eda/basic_eda_statistics.json`
@@ -100,6 +125,9 @@ python 01_basic_eda.py --config ../../config.yaml --sample 10000
 - Deep comparison of Buy vs Sell trades across profitability, drawdown, efficiency, and cadence metrics.
 - Optional sampling + metric filters to focus on specific KPIs defined in `analysis/config.yaml`.
 - Generates ticker-level directional bias tables to support hedging and pair selection.
+
+**Why run it**:
+- Surfaces whether the strategy needs hedging or direction-specific throttles by contrasting win rates, profit factors, and drawdowns between buys and sells.【F:analysis/generic/scripts/02_trade_type_analysis.py†L45-L144】
 
 **Outputs**:
 - `directional_summary.csv`
@@ -157,6 +185,9 @@ python 03_cascade_analysis.py --config ../../config.yaml
 - `stop_loss_summary.json`
 - Console summary with optimal threshold + P&L impact.
 
+**Why run it**:
+- Quantifies whether additional risk controls help or hurt by comparing baseline vs simulated P&L and win rates for each threshold sweep.【F:analysis/generic/scripts/04_stop_loss_simulation.py†L47-L160】
+
 **Example**:
 ```powershell
 python 04_stop_loss_simulation.py --config ../../config.yaml
@@ -177,6 +208,9 @@ python 04_stop_loss_simulation.py --config ../../config.yaml
 - `bottom_performers.csv`
 - `ticker_analysis_summary.json`
 
+**Why run it**:
+- Produces a ranked whitelist that portfolio scripts and options replay can consume, balancing profitability, drawdown, consistency, and efficiency metrics.【F:analysis/generic/scripts/05_ticker_ranking.py†L60-L180】
+
 **Example**:
 ```powershell
 python 05_ticker_ranking.py --config ../../config.yaml
@@ -193,6 +227,9 @@ python 05_ticker_ranking.py --config ../../config.yaml
 **Outputs**:
 - `validation_report.md`
 - Console warnings for missing data or suspicious metrics.
+
+**Why run it**:
+- Final gate before portfolio construction—emits Markdown dossiers with sample trades, column coverage, and consecutive-trade reviews so reviewers can sign off on data quality.【F:analysis/generic/scripts/09_validation_check.py†L40-L160】
 
 **Example**:
 ```powershell

--- a/analysis/generic/README.md
+++ b/analysis/generic/README.md
@@ -10,11 +10,14 @@
 | Script | Description | Status |
 |--------|-------------|--------|
 | `01_basic_eda.py` | Overall statistics, win rate, profit factor | ✅ Ready |
-| `02_trade_type_analysis.py` | Buy vs Sell comparison | ⏳ To be migrated |
-| `03_cascade_analysis.py` | Sequential trade patterns | ✅ Ready |
-| `04_ticker_ranking.py` | Rank tickers by performance | ⏳ To be migrated |
-| `05_exit_timing.py` | Optimal holding periods | ⏳ To be migrated |
-| `06_stop_loss_sim.py` | Stop loss simulation | ⏳ To be migrated |
+| `02_trade_type_analysis.py` | Directional (buy vs sell) performance deep dive | ✅ Ready |
+| `03_cascade_analysis.py` | Sequential trade pattern tagging & analysis | ✅ Ready |
+| `04_stop_loss_simulation.py` | Percentage stop-loss sweeps & recommendations | ✅ Ready |
+| `05_ticker_ranking.py` | Weighted ranking + filter pipeline for top tickers | ✅ Ready |
+| `06_risk_adjusted_patterns.py` | Risk-adjusted motif analytics & exposure heatmaps | ✅ Ready |
+| `07_top50_vs_overall.py` | Compare Top-50 portfolio vs entire trade universe | ✅ Ready |
+| `08_top50_pattern_breakdown.py` | Drill down into Top-50 constituent behavior | ✅ Ready |
+| `09_validation_check.py` | Runbook of guard-rail checks before portfolio build | ✅ Ready |
 
 ---
 
@@ -48,8 +51,20 @@ cd generic/scripts
 # Basic EDA
 python 01_basic_eda.py --config ../../config.yaml
 
-# Cascade Analysis
+# Directional performance
+python 02_trade_type_analysis.py --config ../../config.yaml
+
+# Cascade Analysis (momentum vs mean-reversion patterns)
 python 03_cascade_analysis.py --config ../../config.yaml
+
+# Stop-loss sweep (thresholds configured in YAML)
+python 04_stop_loss_simulation.py --config ../../config.yaml
+
+# Weighted ticker ranking for portfolio prep
+python 05_ticker_ranking.py --config ../../config.yaml
+
+# Validation guard-rails before downstream workflows
+python 09_validation_check.py --config ../../config.yaml
 ```
 
 ---
@@ -75,6 +90,27 @@ python 01_basic_eda.py --config ../../config.yaml
 
 # With sampling for quick test
 python 01_basic_eda.py --config ../../config.yaml --sample 10000
+```
+
+---
+
+### **02_trade_type_analysis.py**
+
+**What it does**:
+- Deep comparison of Buy vs Sell trades across profitability, drawdown, efficiency, and cadence metrics.
+- Optional sampling + metric filters to focus on specific KPIs defined in `analysis/config.yaml`.
+- Generates ticker-level directional bias tables to support hedging and pair selection.
+
+**Outputs**:
+- `directional_summary.csv`
+- `directional_summary.json`
+- `directional_summary.md`
+- `ticker_bias.csv`
+
+**Example**:
+```powershell
+python 02_trade_type_analysis.py --config ../../config.yaml
+python 02_trade_type_analysis.py --config ../../config.yaml --sample 5000
 ```
 
 ---
@@ -109,6 +145,67 @@ python 03_cascade_analysis.py --config ../../config.yaml
 **Key Insight**: If "trades after a loss" have <45% win rate, consider blocking them!
 
 ---
+
+### **04_stop_loss_simulation.py**
+
+**What it does**:
+- Sweeps configurable stop-loss thresholds, highlights optimal protection levels, and surfaces performance deltas.
+- Supports scenario comparisons (base vs optimal) and prints narrative recommendations.
+
+**Outputs**:
+- `stop_loss_scenarios.csv`
+- `stop_loss_summary.json`
+- Console summary with optimal threshold + P&L impact.
+
+**Example**:
+```powershell
+python 04_stop_loss_simulation.py --config ../../config.yaml
+```
+
+---
+
+### **05_ticker_ranking.py**
+
+**What it does**:
+- Computes composite scores blending profitability, risk, efficiency, and consistency measures.
+- Applies liquidity + minimum trade filters before generating ranked tables and JSON summaries.
+- Produces tiered segments (S/A/B...) that integrate directly with portfolio construction scripts.
+
+**Outputs**:
+- `ticker_scores.csv`
+- `top_performers.csv`
+- `bottom_performers.csv`
+- `ticker_analysis_summary.json`
+
+**Example**:
+```powershell
+python 05_ticker_ranking.py --config ../../config.yaml
+```
+
+---
+
+### **09_validation_check.py**
+
+**What it does**:
+- Runs guard-rail checks (required columns, win-rate sanity, consecutive trade sampling) before handing data to portfolio engines.
+- Generates a Markdown dossier with sample trades to accelerate manual QA.
+
+**Outputs**:
+- `validation_report.md`
+- Console warnings for missing data or suspicious metrics.
+
+**Example**:
+```powershell
+python 09_validation_check.py --config ../../config.yaml
+```
+
+---
+
+### **Additional Modules**
+
+- `06_risk_adjusted_patterns.py`: Heatmaps risk-adjusted motifs (volatility buckets, holding-period cohorts).
+- `07_top50_vs_overall.py`: Benchmarks the curated Top-50 ticker set against the full trade universe.
+- `08_top50_pattern_breakdown.py`: Dissects Top-50 combinations for cascade, sector, and regime behaviour.
 
 ## 🔧 **Requirements**
 

--- a/src/core/options/README.md
+++ b/src/core/options/README.md
@@ -1,83 +1,72 @@
 # Options Backtesting Module
 
-**Status**: Planning & Development Phase
-**Version**: 0.1.0 (Pre-MVP)
-**Last Updated**: 2025-10-08
+**Status**: Phase 4 replay complete (production hybrid pricing)
+**Version**: 0.4.0
+**Last Updated**: 2025-10-11
 
 ---
 
 ## Overview
+The options stack extends the equity backtester with a fully validated replay engine, hybrid pricing that blends actual Upstox chains with synthetic Black–Scholes fills, and reporting manifests that prove out multi-ticker production runs. Phase 3 and Phase 4 completion reports document the throughput, data quality, and profitability delivered by the replay engine across RELIANCE, TCS, INFY, NIFTY, and BANKNIFTY contracts.
 
-This module extends the existing equity backtesting system to support **options trading strategies**. The primary goal is to validate whether equity trading signals can be effectively executed using options contracts, and to compare performance, risk, and capital efficiency.
-
-### Core Capabilities
-
-- **Replay Engine**: Re-execute equity trades using options contracts
-- **Dual Pricing**: Support both synthetic (Black-Scholes) and actual historical option prices
-- **Strike/Expiry Selection**: Configurable logic for contract selection
-- **Position Tracking**: Bar-by-bar tracking with Greeks calculation
-- **Validation Framework**: Measure synthetic pricing accuracy vs market reality
-- **Comparison Analytics**: Equity vs Options performance reports
+Key capabilities include:
+- Automated data ingestion from Upstox with cached parquet storage, metadata tracking, and WiFinance parity fallbacks where the daily equity feed is still pending.
+- Pricing infrastructure that calibrates implied volatility, compares synthetic vs actual fills, and recommends the correct mode (synthetic, actual, or hybrid) before replaying trades.
+- A replay engine that maps equity signals into option trades, enforces risk rules, and produces CSV/JSON artifacts alongside structured logs.
 
 ---
 
-## Quick Start
+## Feature Highlights
 
-### Prerequisites
+### 1. Data & Validation Pipeline
+- `validation/data_fetcher.py` fetches historical option chains via Upstox, writes deterministic parquet layouts, and produces JSON summaries of coverage.
+- `validation/pricing_validator.py` benchmarks synthetic, actual, and hybrid pricing accuracy to generate production recommendations.
+- `validation/data_storage.py` and `validation/README.md` capture the on-disk schema, troubleshooting flows, and storage guarantees.
 
-1. **Existing Equity Backtest Results**:
-   - `trades.csv` - Equity trade ledger
-   - `base_data.csv` - Bar-by-bar underlying price data
+### 2. Pricing & Greeks
+- `options_engine.py` implements the Black–Scholes engine with full Greeks for synthetic fills.
+- `replay/pricing.py` orchestrates hybrid pricing, selecting actual OHLC data where available and falling back to synthetic outputs otherwise.
+- `pricing/synthetic_engine.py` and `pricing/volatility_models.py` package volatility calibration and reusable pricing helpers.
 
-2. **Upstox API Access** (for actual historical data):
-   - Active Upstox Plus subscription
-   - API credentials configured in `config/config.py`
+### 3. Replay & Risk Management
+- `replay/engine.py` drives the end-to-end replay, coordinating data loading, trade mapping, pricing, and artifact emission.
+- `replay/data_loader.py` discovers parquet/CSV sources across ticker-first layouts, builds option data stores, and aligns equity + option timeframes.
+- `replay/risk.py` enforces position sizing, exposure caps, and per-trade guardrails before outputting option executions.
+- `replay/metrics.py` aggregates trade-level metrics, Sharpe/Drawdown stats, and pricing diagnostics for reports.
 
-3. **Python Dependencies**:
+### 4. Reporting & Manifests
+- Phase completion documents (`PHASE3_COMPLETE.md`, `PHASE4_COMPLETE.md`) summarise KPIs, fallback ratios, and timeline traces.
+- `VALIDATION_REPORT.md`, `PHASE1_STATUS.md`, and `PHASE2_READINESS_ASSESSMENT.md` log historical validation decisions, data dependencies, and open risks.
+
+---
+
+## Quick Start Workflow
+
+1. **Fetch a validation dataset**
    ```bash
-   pip install pandas numpy scipy pyyaml tqdm
+   python src/core/options/validation/data_fetcher.py \
+     --ticker RELIANCE \
+     --timeframe 1day \
+     --max-expiries 1 \
+     --log-level INFO
    ```
+   This writes parquet chains under `data/pools/options/<date_range>/<ticker>/<timeframe>/` and prints a coverage summary.
 
-### Phase 1: Data Validation (Current Phase)
+2. **Run pricing validation**
+   ```bash
+   python - <<'PY'
+   from src.core.options.validation.pricing_validator import run_pricing_validation
+   result = run_pricing_validation()
+   print(result["summary"]["recommendation"])
+   PY
+   ```
+   The validator emits aggregated CSV/JSON reports in `src/core/options/data/validation_results/` and recommends the correct pricing mode for replay.
 
-**Objective**: Measure synthetic pricing accuracy
-
-```bash
-# 1. Configure validation parameters
-# Edit: src/core/options/validation/validation_config.yaml
-
-# 2. Run validation (script to be implemented)
-python src/core/options/validation/validation_runner.py
-
-# 3. Review results
-cat src/core/options/data/validation_results/pricing_validation_summary.csv
-```
-
-**Expected Output**:
-- Pricing error metrics by ticker, model, moneyness, DTE
-- Recommendation on which pricing mode to use (synthetic/actual/hybrid)
-
-### Phase 2: MVP Replay (Next Phase)
-
-**Objective**: Run first options backtest on small dataset
-
-```bash
-# 1. Configure options parameters
-# Edit: src/core/options/config/options_config.yaml
-
-# 2. Run replay engine (script to be implemented)
-python src/core/options/replay/replay_runner.py \
-  --equity-trades outputs/20240101_120000/trades.csv \
-  --base-data outputs/20240101_120000/base_data.csv \
-  --ticker RELIANCE \
-  --output-dir outputs/options_mvp
-
-# 3. Review outputs
-ls outputs/options_mvp/
-# - options_trades.csv
-# - options_base_data.csv
-# - options_metrics.json
-```
+3. **Execute the replay engine**
+   ```bash
+   python run_phase4_backtest.py
+   ```
+   The Phase 4 runner loads sample equity trades, launches the replay engine across five tickers, and saves metrics, trades, positions, manifests, and structured logs under `outputs/phase4_backtest/options_replay/`.
 
 ---
 
@@ -85,502 +74,48 @@ ls outputs/options_mvp/
 
 ```
 src/core/options/
-├── README.md                       # This file
-├── options_engine.py               # EXISTING: Black-Scholes pricing + Greeks
-│
-├── planning/
-│   ├── implementation_plan.md      # Comprehensive planning document
-│   └── decisions.md                # Architecture decision records (TBD)
-│
+├── PHASE1_STATUS.md / PHASE2_READINESS_ASSESSMENT.md / PHASE3_COMPLETE.md / PHASE4_COMPLETE.md
+│   └── Status reports, validation outcomes, and production sign-off
+├── README.md                      # (this file)
+├── options_engine.py              # Black–Scholes pricing + Greeks
+├── config/
+│   └── options_config.yaml        # Master configuration for replay runs
 ├── validation/
-│   ├── __init__.py                 # (To be created)
-│   ├── validation_config.yaml      # Validation parameters
-│   ├── pricing_validator.py        # Synthetic vs actual comparison (TBD)
-│   ├── data_fetcher.py             # Fetch historical options from Upstox (TBD)
-│   └── validation_runner.py        # Main validation orchestrator (TBD)
-│
+│   ├── README.md                  # Operational runbook for data + validation
+│   ├── config_loader.py           # Loads validation YAMLs and CLI overrides
+│   ├── data_fetcher.py            # Upstox fetcher with caching + summaries
+│   ├── data_storage.py            # Parquet persistence and metadata helpers
+│   ├── pricing_validator.py       # Hybrid vs actual vs synthetic evaluation
+│   └── upstox_options_api.py      # API bindings and rate-limit helpers
 ├── pricing/
-│   ├── __init__.py                 # (To be created)
-│   ├── synthetic_engine.py         # Black-Scholes implementations (TBD)
-│   ├── actual_engine.py            # Historical data pricing (TBD)
-│   ├── hybrid_engine.py            # Combined approach (TBD)
-│   └── volatility_models.py        # Historical vol, Parkinson, EWMA (TBD)
-│
+│   ├── synthetic_engine.py        # Synthetic pricing utilities
+│   └── volatility_models.py       # Volatility estimators (historical, EWMA)
 ├── replay/
-│   ├── __init__.py                 # (To be created)
-│   ├── trade_mapper.py             # Equity → option contract mapping (TBD)
-│   ├── position_tracker.py         # Bar-by-bar position tracking (TBD)
-│   ├── metrics_calculator.py       # Performance metrics (TBD)
-│   └── replay_runner.py            # Main orchestrator (TBD)
-│
+│   ├── config.py                  # Dataclasses + YAML loader for replay config
+│   ├── data_loader.py             # Discovers equity + option data stores
+│   ├── engine.py                  # Core orchestrator (multiprocessing aware)
+│   ├── metrics.py                 # Portfolio-level reporting helpers
+│   ├── pricing.py                 # Hybrid pricing wrapper used during replay
+│   ├── risk.py                    # Position sizing + guardrails
+│   └── trade_mapper.py            # Equity-to-option mapping logic
 ├── data/
-│   ├── cache/                      # Cached options data (parquet)
-│   ├── validation_results/         # Validation reports
-│   ├── schemas.py                  # Data schemas (TBD)
-│   └── lot_sizes.csv               # Ticker → lot size mapping
-│
-└── config/
-    └── options_config.yaml         # Options backtesting configuration
-```
-
-**Legend**:
-- ✅ **EXISTING**: Already implemented
-- 📄 **Created**: File exists (config/docs)
-- ⏳ **TBD**: To be developed in upcoming phases
-
----
-
-## Key Concepts
-
-### 1. Pricing Modes
-
-**Synthetic Mode**:
-- Uses Black-Scholes model with historical volatility
-- Fast, works for any time period
-- Approximate (may not reflect market reality)
-- Best for: Initial strategy validation
-
-**Actual Mode**:
-- Uses real historical option OHLC from Upstox
-- Accurate, reflects true market conditions
-- Limited to data availability (~6 months)
-- Best for: Final validation before live trading
-
-**Hybrid Mode** (Recommended):
-- Uses actual data when available
-- Falls back to synthetic for gaps
-- Balances accuracy and coverage
-- Best for: Production backtesting
-
-### 2. Strike Selection Methods
-
-**ATM (At-The-Money)**:
-- Strike closest to underlying price
-- Moderate delta (~0.50), balanced theta/gamma
-- Most liquid, tightest spreads
-
-**Delta-Based**:
-- Select strike with specific delta (e.g., 0.30)
-- Allows OTM/ITM targeting
-- Delta changes with underlying movement
-
-**Moneyness**:
-- Strike as % of underlying (e.g., 105% = 5% OTM call)
-- Fixed distance from price
-- Simple, deterministic
-
-**Premium %**:
-- Option costs specific % of underlying (e.g., 2%)
-- Capital-based selection
-- Varies by volatility regime
-
-### 3. Lot Sizing Strategies
-
-**Fixed Lots**:
-- Always trade N lots (e.g., 1 lot)
-- Simplest, clean comparisons
-- Capital deployed varies by option premium
-
-**Capital Matching**:
-- Deploy same ₹ as equity trade
-- Lots = equity_capital / (option_premium × lot_size)
-- May result in fractional lots (round to integer)
-
-**Delta Matching**:
-- Match notional underlying exposure
-- Accounts for delta < 1.0
-- Most accurate risk replication
-
-### 4. Greeks
-
-**Delta**: Sensitivity to underlying price change (0 to 1 for calls)
-**Gamma**: Rate of delta change
-**Theta**: Time decay (typically negative for long positions)
-**Vega**: Sensitivity to volatility changes
-**Rho**: Sensitivity to interest rate (usually negligible for short-dated)
-
----
-
-## Configuration
-
-### Primary Config: `config/options_config.yaml`
-
-**Key Parameters**:
-
-```yaml
-pricing:
-  mode: "hybrid"  # synthetic | actual | hybrid
-
-strike_selection:
-  method: "atm"  # atm | delta | moneyness | premium_pct
-
-expiry_selection:
-  method: "nearest_weekly"  # nearest_weekly | nearest_monthly | fixed_dte
-
-lot_sizing:
-  method: "fixed"  # fixed | capital_match | delta_match
-  fixed:
-    lots_per_trade: 1
-
-position_management:
-  entry:
-    min_dte_to_enter: 3
-  exit:
-    follow_equity_signal: true
-    force_close_before_expiry:
-      enabled: true
-      hours_before: 24
-```
-
-See file for full documentation of all parameters.
-
-### Validation Config: `validation/validation_config.yaml`
-
-**Key Parameters**:
-
-```yaml
-validation:
-  tickers:
-    - "NIFTY"
-    - "BANKNIFTY"
-    - "RELIANCE"
-    - "TCS"
-    - "INFY"
-  time_period:
-    months: 6
-
-synthetic_models:
-  bs_hist_20d:
-    enabled: true
-  bs_calibrated_iv:
-    enabled: true
-
-decision_criteria:
-  thresholds:
-    good:
-      atm_median_error: 0.10
+│   ├── lot_sizes.csv              # Contract lot metadata
+│   ├── schemas.py                 # Schema helpers for saved artefacts
+│   └── validation_results/        # Pricing validation outputs (CSV/Parquet)
+└── planning/ / config/ etc.       # Historical planning docs and templates
 ```
 
 ---
 
-## Data Schemas
-
-### Options Trade Ledger (`options_trades.csv`)
-
-| Column | Type | Description |
-|--------|------|-------------|
-| trade_id | int | Unique trade identifier |
-| underlying | str | Ticker symbol (e.g., 'RELIANCE') |
-| option_type | str | 'CE' (call) or 'PE' (put) |
-| strike | float | Strike price |
-| expiry | datetime | Expiry date |
-| entry_time | datetime | Entry timestamp |
-| exit_time | datetime | Exit timestamp |
-| entry_price | float | Option premium at entry |
-| exit_price | float | Option premium at exit |
-| lots | int | Number of lots traded |
-| lot_size | int | Contracts per lot |
-| quantity | int | Total contracts (lots × lot_size) |
-| entry_cost | float | Total capital deployed (₹) |
-| exit_value | float | Total exit value (₹) |
-| realized_pnl | float | Profit/Loss (₹) |
-| realized_pnl_pct | float | P&L % |
-| hold_time_hours | float | Duration of position |
-| dte_at_entry | float | Days to expiry at entry |
-| dte_at_exit | float | Days to expiry at exit |
-| pricing_mode | str | 'synthetic' | 'actual' | 'hybrid' |
-| exit_reason | str | Why position closed |
-
-### Position Lifecycle (`options_base_data.csv`)
-
-| Column | Type | Description |
-|--------|------|-------------|
-| trade_id | int | Links to options_trades.csv |
-| timestamp | datetime | Bar timestamp |
-| underlying_price | float | Underlying asset price |
-| option_price | float | Option premium |
-| position_value | float | Mark-to-market value (₹) |
-| unrealized_pnl | float | Unrealized P&L (₹) |
-| unrealized_pnl_pct | float | Unrealized P&L % |
-| dte_remaining | float | Days to expiry remaining |
-| delta | float | Option delta |
-| gamma | float | Option gamma |
-| theta | float | Option theta |
-| vega | float | Option vega |
-| pricing_mode | str | Which pricing mode used |
-
-### Metrics Output (`options_metrics.json`)
-
-```json
-{
-  "summary": {
-    "total_trades": 1523,
-    "win_rate": 0.645,
-    "total_pnl": 2458300,
-    "sharpe_ratio": 1.87,
-    "max_drawdown_pct": -18.4,
-    ...
-  },
-  "by_ticker": { ... },
-  "options_specific": {
-    "theta_capture_total": 125600,
-    "gamma_pnl_total": 342100,
-    ...
-  }
-}
-```
+## Operational Notes & Caveats
+- **Equity reference feed**: WiFinance daily reference prices are still pending; manual overrides remain in place until the upstream feed is restored (see `PHASE1_STATUS.md`).
+- **Data footprint**: Ensure the equity parquet pool (`data/pools/2022-01-01_to_2025-08-31/<ticker>/`) is available before running replay or validation jobs.
+- **Hybrid pricing**: `options_config.yaml` defaults to `mode: "hybrid"`; adjust to `synthetic` or `actual` only if validation recommends it.
+- **Testing**: `test_phase3_integration.py` smoke-tests the replay engine against staged parquet fixtures, while `run_phase4_backtest.py` performs the full multi-ticker validation run.
 
 ---
 
-## Implementation Phases
-
-### Phase 0: Preparation ✅
-- ✅ Directory structure
-- ✅ Planning documentation
-- ✅ Configuration templates
-- ✅ Lot size reference data
-
-### Phase 1: Data Validation ⏳ (Current)
-**Timeline**: Weeks 2-3
-
-**Tasks**:
-1. Implement data fetcher (Upstox API)
-2. Implement 4 synthetic pricing models
-3. Run validation experiment (6 months, 5 tickers)
-4. Generate validation report
-5. **Decision**: Choose pricing mode
-
-**Deliverables**:
-- `pricing_validation_summary.csv`
-- `validation_metrics.json`
-- Recommendation document
-
-### Phase 2: MVP Replay Engine ⏳
-**Timeline**: Weeks 4-5
-
-**Tasks**:
-1. Implement Trade Mapper
-2. Implement Position Tracker
-3. Implement Metrics Calculator
-4. Test on 1 ticker, 1 month
-5. Debug and validate
-
-**Deliverables**:
-- Working replay engine
-- Test results on small dataset
-
-### Phase 3: Actual Data Integration ⏳
-**Timeline**: Weeks 6-7
-
-**Tasks**:
-1. Add actual pricing mode
-2. Implement hybrid mode
-3. Re-run MVP with all pricing modes
-4. Compare synthetic vs actual results
-5. **Decision**: Hybrid viable?
-
-### Phase 4: Full Backtest ⏳
-**Timeline**: Weeks 8-10
-
-**Tasks**:
-1. Scale to all 5 tickers, 6 months
-2. Add configuration support
-3. Run sensitivity analysis
-4. Generate comprehensive reports
-
-**Deliverables**:
-- Full backtest results
-- Equity vs Options comparison
-- Sensitivity analysis
-- Recommendations for live trading
-
----
-
-## Open Questions
-
-Critical decisions to be made during implementation:
-
-1. **Capital Allocation**: How to match equity position sizes to option lots?
-2. **Exit Logic**: Follow equity exits only, or add options-specific risk management?
-3. **Option Type for SHORT**: Buy puts vs sell calls vs spreads?
-4. **Data Fetching**: Pre-fetch all or on-demand?
-5. **Fractional Lots**: How to handle rounding?
-6. **Fill Prices**: Open/close/mid/VWAP?
-7. **Liquidity Filters**: When to skip illiquid contracts?
-8. **Volatility Regimes**: Adjust strategy based on vol?
-9. **Roll Logic**: Handle expiries or let positions close?
-10. **Greeks Frequency**: Calculate every bar or optimize?
-
-See `planning/implementation_plan.md` for detailed discussion and current decisions.
-
----
-
-## Expected Outputs
-
-### Validation Phase
-- **File**: `data/validation_results/pricing_validation_summary.csv`
-- **Purpose**: Determine synthetic pricing accuracy
-- **Columns**: Ticker, Model, Moneyness, DTE_Range, Error_Metrics
-
-### Backtest Phase
-- **File**: `outputs/{run_id}/options_trades.csv` - Trade ledger
-- **File**: `outputs/{run_id}/options_base_data.csv` - Position lifecycle
-- **File**: `outputs/{run_id}/options_metrics.json` - Performance stats
-- **File**: `outputs/{run_id}/comparison_equity_vs_options.csv` - Side-by-side
-- **File**: `outputs/{run_id}/sensitivity_analysis.csv` - Parameter impact
-
----
-
-## Testing & Validation
-
-### Unit Tests (To Be Implemented)
-- Black-Scholes calculations (exact values)
-- Greeks calculations (known test cases)
-- Strike selection logic (edge cases)
-- Lot size rounding (fractional handling)
-
-### Integration Tests
-- End-to-end replay on small dataset
-- Validation of P&L calculations
-- Expiry handling (positions auto-close)
-- Data quality checks
-
-### Validation Checks
-- ✅ No negative option prices
-- ✅ No positions held past expiry
-- ✅ P&L balances (unrealized → realized)
-- ✅ Greeks within bounds (delta 0-1, etc.)
-- ✅ No lookahead bias
-
----
-
-## Dependencies
-
-### External APIs
-- **Upstox API**: Historical options data
-  - Endpoints: `/v2/expired-instruments/*`
-  - Auth: OAuth2 (managed in main config)
-  - Rate limits: 5 req/sec, 100 req/min
-
-### Internal Dependencies
-- **Equity Backtester**: Provides `trades.csv`, `base_data.csv`
-- **Data Provider Layer**: Reuse existing Upstox integration
-- **Config System**: Extend existing YAML-based config
-
-### Python Libraries
-- `pandas`, `numpy`: Data processing
-- `scipy`: Black-Scholes (normal distribution)
-- `pyyaml`: Config parsing
-- `tqdm`: Progress bars
-- `matplotlib`/`seaborn`: Visualization (Phase 4)
-
----
-
-## Performance Considerations
-
-### Data Volume
-- **Validation**: ~300K data points (5 tickers × 6 months × 20 strikes × 125 days)
-- **Full Backtest**: ~1M data points (1,500 trades × bar-by-bar tracking)
-
-### Optimization Strategies
-- ✅ Parquet format (compressed, columnar)
-- ✅ Vectorized pandas operations (no Python loops)
-- ✅ Caching (vol calculations, Greeks)
-- ⏳ Parallel processing (multi-ticker)
-- ⏳ Chunked processing (avoid OOM)
-
-### Memory Management
-- Process tickers sequentially (for large datasets)
-- Clear intermediate DataFrames
-- Use generators for large file reads
-
----
-
-## Contributing
-
-### Code Style
-- **Files**: `snake_case.py`
-- **Classes**: `PascalCase`
-- **Functions**: `snake_case()`
-- **Type hints**: All public functions
-- **Docstrings**: Google style
-
-### Development Workflow
-1. Create feature branch: `git checkout -b feature/pricing-engine`
-2. Implement with tests
-3. Run validation checks
-4. Update documentation
-5. Submit for review
-
-### Documentation
-- Update `README.md` when adding features
-- Document architectural decisions in `planning/decisions.md`
-- Add inline comments for complex logic
-- Keep `implementation_plan.md` in sync
-
----
-
-## Troubleshooting
-
-### Common Issues
-
-**Issue**: Upstox API rate limit exceeded
-**Solution**: Reduce `requests_per_second` in `validation_config.yaml`, enable caching
-
-**Issue**: Options data not available for ticker/date
-**Solution**: Check Upstox Plus subscription, verify ticker has listed options, try different date range
-
-**Issue**: Synthetic prices wildly different from actual
-**Solution**: Review volatility model choice, check for data quality issues in underlying, consider using calibrated IV model
-
-**Issue**: Positions held past expiry
-**Solution**: Verify `force_close_before_expiry` is enabled, check expiry date format, ensure DTE calculation is correct
-
-**Issue**: P&L doesn't balance (unrealized ≠ realized at exit)
-**Solution**: Check for missing bars in `base_data.csv`, verify option pricing at exit timestamp, review rounding errors
-
----
-
-## Resources
-
-### Internal Documentation
-- `planning/implementation_plan.md` - Comprehensive planning doc
-- `planning/decisions.md` - Architecture decisions (TBD)
-- `config/options_config.yaml` - Full config reference
-- `validation/validation_config.yaml` - Validation parameters
-
-### External References
-- [Upstox API Docs](https://upstox.com/developer/api-documentation/)
-- [Black-Scholes Model](https://en.wikipedia.org/wiki/Black%E2%80%93Scholes_model)
-- [Options Greeks Explained](https://www.investopedia.com/trading/using-the-greeks-to-understand-options/)
-- [Parkinson Volatility](https://en.wikipedia.org/wiki/Volatility_(finance)#Parkinson_volatility)
-
----
-
-## License
-
-Part of StrategyLab proprietary codebase. All rights reserved.
-
----
-
-## Changelog
-
-### v0.1.0 (2025-10-08)
-- Initial planning and setup
-- Directory structure created
-- Configuration templates defined
-- Implementation plan documented
-
----
-
-## Contact
-
-For questions or issues related to options backtesting:
-- Review `planning/implementation_plan.md` first
-- Check open questions in this README
-- Consult with team lead
-
----
-
-**Last Updated**: 2025-10-08
-**Next Milestone**: Phase 1 (Data Validation) completion
+## Next Steps
+- Wire `run_phase4_backtest.py` into CI once the data pool is mirrored in non-production environments.
+- Expand coverage beyond the initial five tickers by reusing the validation fetcher and updating `options_config.yaml` weightings.
+- Integrate options analytics with the generic analysis framework so equity and option trade diagnostics share the same reporting surface.

--- a/src/core/options/README.md
+++ b/src/core/options/README.md
@@ -70,6 +70,45 @@ Key capabilities include:
 
 ---
 
+## Hypothesis Lifecycle & Trade Simulation
+
+1. **Frame the options hypothesis**
+   - Start with a validated equity thesis (e.g., "trend-following longs should be hedged with near-term calls").
+   - Express the replay assumptions in `config/options_config.yaml`—inputs, strike selection, risk guardrails, and logging—so the engine knows which trades, data pools, and pricing mode to use.【F:src/core/options/config/options_config.yaml†L1-L120】【F:src/core/options/replay/config.py†L20-L118】
+
+2. **Acquire and verify the option surface**
+   - Run the validation fetcher to build an options parquet lake and inspect the JSON summary for missing expiries or strikes.【F:src/core/options/validation/data_fetcher.py†L32-L190】
+   - Execute `pricing_validator.py` to calibrate implied volatility, compare synthetic vs actual fills, and document the recommended pricing mode before running any replay experiments.【F:src/core/options/validation/pricing_validator.py†L63-L348】
+
+3. **Map equity trades to option contracts**
+   - The replay engine loads merged equity trades, aligns them with the underlying OHLCV cache, and chooses expiries/strikes that satisfy the configured DTE and ATM requirements.【F:src/core/options/replay/data_loader.py†L51-L258】【F:src/core/options/replay/trade_mapper.py†L1-L74】
+   - Metadata describing strike source, expiry type, and pricing context is captured alongside each mapped trade, ensuring downstream attribution.
+
+4. **Synthesize option executions**
+   - Hybrid pricing evaluates each contract path-by-path, blending actual Upstox bars with synthetic Black–Scholes fills when intraday data is missing, and records every pricing decision in structured logs.【F:src/core/options/replay/pricing.py†L52-L238】【F:src/core/options/replay/engine.py†L1-L188】
+   - The risk manager enforces allocation, concurrency, and kill-switch rules before confirming or rejecting entries, so hypotheses are judged under real capital constraints.【F:src/core/options/replay/risk.py†L22-L192】
+
+5. **Generate trade analytics and manifests**
+   - Replay metrics aggregate realized P&L, Greeks exposure, fallback ratios, and pricing variance into CSV/JSON outputs for inspection or import into the analysis framework.【F:src/core/options/replay/metrics.py†L19-L162】
+   - Completion manifests (`PHASE3_COMPLETE.md`, `PHASE4_COMPLETE.md`) link each run to validation evidence, allowing reviewers to trace assumptions back to data quality checks.
+
+6. **Feed results into portfolio or risk review**
+   - Use `analysis/generic` modules (e.g., cascade analysis, stop-loss sweeps) on the replay output to compare option-adjusted outcomes against the base equity performance.
+   - Iterate on the hypothesis by editing the YAML config and repeating the cycle; structured logs and run directories provide reproducible artefacts for each revision.
+
+---
+
+## Quality Gates & Tests
+
+- **Unit safeguards**: `tests/options/replay/test_risk_manager.py` validates allocation and kill-switch behaviour so oversized trades are blocked before execution.【F:tests/options/replay/test_risk_manager.py†L1-L36】
+- **Data store fallbacks**: `tests/options/replay/test_phase4_behaviour.py::test_option_data_store_intraday_fallback` proves the loader falls back to daily bars when minute data is absent, ensuring continuity across sparse expiries.【F:tests/options/replay/test_phase4_behaviour.py†L32-L89】
+- **Replay ordering**: `tests/options/replay/test_phase4_behaviour.py::test_replay_engine_multi_ticker_ordering` exercises the engine’s scheduling logic so mixed ticker portfolios process deterministically before pricing.【F:tests/options/replay/test_phase4_behaviour.py†L91-L170】
+- **Integration smoke test**: `test_phase3_integration.py` and `run_phase4_backtest.py` execute the entire replay stack against staged parquet pools, generating manifests and logs that mirror production validation.【F:test_phase3_integration.py†L1-L210】【F:run_phase4_backtest.py†L1-L153】
+
+These checks make the replay deterministic, reproducible, and regression-friendly when expanding coverage to new instruments or strategies.
+
+---
+
 ## Directory Structure
 
 ```
@@ -119,3 +158,4 @@ src/core/options/
 - Wire `run_phase4_backtest.py` into CI once the data pool is mirrored in non-production environments.
 - Expand coverage beyond the initial five tickers by reusing the validation fetcher and updating `options_config.yaml` weightings.
 - Integrate options analytics with the generic analysis framework so equity and option trade diagnostics share the same reporting surface.
+- Restore the WiFinance equity reference feed (see `PHASE1_STATUS.md`) and remove temporary overrides once parity reports confirm accuracy.【F:src/core/options/PHASE1_STATUS.md†L34-L57】


### PR DESCRIPTION
## Summary
- highlight the production-ready options pipeline, crypto data sources, and parquet-first storage in the main README
- update the analysis implementation status and generic analysis README to reflect nine migrated modules and the remaining backlog
- rewrite the options module README with current phase-complete workflows, directory guidance, and quick-start commands

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ece1d7c55083309339cddb34b198d2